### PR TITLE
feat(zsh): include hidden folders in tab completion

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -127,3 +127,6 @@ alias -s {cs,ts,html}=code
 
 # Python env (pyenv)
 eval "$(pyenv init --path)"
+
+# Include dotfiles (hidden folders) in tab completion
+_comp_options+=(globdots)


### PR DESCRIPTION
Tab completion skips dot-directories by default unless the typed prefix starts with `.`.

Adding `_comp_options+=(globdots)` so completion offers hidden folders (`.config`, `.ssh`, …) without typing the leading dot. Scoped to completion only — does not enable `globdots` globally, so glob expansions like `rm *` are unaffected.