### PR TITLE
chore(homebrew): add sandvault to Brewfile

### DIFF
--- a/homebrew/Brewfile
+++ b/homebrew/Brewfile
@@ -8,6 +8,7 @@ brew "zsh"
 brew "yarn"
 brew "fzf"
 brew "duti"
+brew "sandvault"
 
 # vim tools
 brew "vim"


### PR DESCRIPTION
## Summary

Adds [`sandvault`](https://formulae.brew.sh/formula/sandvault) to the Homebrew `Brewfile` so it gets installed on `brew bundle`.

`sandvault` is a core Homebrew formula that runs AI agents isolated in a sandboxed macOS user account.

## Details

- Added under the **shell tools** group, since it's a CLI utility.
- No `tap` needed — it lives in `homebrew/core`.

## Install

```sh
brew bundle --file homebrew/Brewfile
```