### PR TITLE
refactor(vim): migrate from vundle to vim-plug

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -69,10 +69,11 @@ sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.
 /opt/homebrew/opt/fzf/install
 
 #==============
-# Initialise Vundle plugins
+# Install vim-plug and plugins
 #==============
-git clone https://github.com/VundleVim/Vundle.vim.git ~/.vim/bundle/Vundle.vim
-vim +PluginInstall +qall
+curl -fLo ~/.vim/autoload/plug.vim --create-dirs \
+  https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+vim +'PlugInstall --sync' +qall
  
 #==============
 # Spaceship theme

--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -1,32 +1,19 @@
-set rtp+=~/.vim/bundle/Vundle.vim
-call vundle#begin()
-" alternatively, pass a path where Vundle should install plugins
-"call vundle#begin('~/some/path/here')
+call plug#begin('~/.vim/plugged')
+Plug 'mg979/vim-visual-multi'   " multiple cursors (successor to terryma/vim-multiple-cursors)
+Plug 'itchyny/lightline.vim'
+Plug 'tpope/vim-surround'
+Plug 'tpope/vim-repeat'         " lets . repeat surround/commentary actions
+Plug 'tpope/vim-commentary'     " gcc / gc{motion} to toggle comments
+Plug 'airblade/vim-gitgutter'
+Plug 'junegunn/fzf.vim'
+Plug 'morhetz/gruvbox'
+call plug#end()
+" plug#end() runs `filetype plugin indent on` and `syntax enable` automatically.
+" Run :PlugInstall to install, :PlugUpdate to update, :PlugClean to prune.
 
-" let Vundle manage Vundle, required
-Plugin 'VundleVim/Vundle.vim'
-Plugin 'terryma/vim-multiple-cursors'
-Plugin 'itchyny/lightline.vim'
-Plugin 'tpope/vim-surround'
-Plugin 'airblade/vim-gitgutter'
-Plugin 'junegunn/fzf.vim'
-
-" All of your Plugins must be added before the following line
-call vundle#end()            " required
-filetype plugin indent on    " required
-" To ignore plugin indent changes, instead use:
-"filetype plugin on
-"
-" Brief help
-" :PluginList       - lists configured plugins
-" :PluginInstall    - installs plugins; append `!` to update or just :PluginUpdate
-" :PluginSearch foo - searches for foo; append `!` to refresh local cache
-" :PluginClean      - confirms removal of unused plugins; append `!` to auto-approve removal
-" 
-" From command line: vim +PluginInstall +qall
-"
-" see :h vundle for more details or wiki for FAQ
-" Put your non-Plugin stuff after this line
+set termguicolors
+set background=dark
+silent! colorscheme gruvbox
 
 au BufNewFile,BufFilePre,BufRead *.md set filetype=markdown
 syntax on


### PR DESCRIPTION
## Summary

Vundle is effectively unmaintained (last meaningful activity ~2018). This swaps it for the actively maintained [vim-plug](https://github.com/junegunn/vim-plug) — same author as the `fzf.vim` already in use — which does parallel async installs and supports lazy loading.

While migrating, refreshed the plugin set (kept lightweight per intent — no LSP/IDE machinery):

| Change | Plugin | Why |
| --- | --- | --- |
| swap | `terryma/vim-multiple-cursors` → `mg979/vim-visual-multi` | the original is archived; this is its maintained successor |
| add | `tpope/vim-repeat` | makes `.` repeat `vim-surround` / `vim-commentary` edits |
| add | `tpope/vim-commentary` | `gcc` / `gc{motion}` comment toggling |
| add | `morhetz/gruvbox` | colorscheme (with `set termguicolors`) |
| keep | `lightline.vim`, `vim-surround`, `vim-gitgutter`, `fzf.vim` | all still maintained |

`fzf.vim` is intentionally left as-is — it relies on Homebrew's `fzf` for its base, which is independent of the plugin manager, so the swap is behavior-preserving there.

## Changes

- **`vim/.vimrc`** — replace the Vundle preamble/`vundle#begin/end` block (and its help comments) with `plug#begin/end`; add `termguicolors` + `silent! colorscheme gruvbox` (the `silent!` avoids an error on a fresh box before `:PlugInstall` runs).
- **`bootstrap.sh`** — install vim-plug via `curl` and run `vim +'PlugInstall --sync' +qall` instead of cloning Vundle. (`--sync` so plugin clones finish before vim exits in the non-interactive bootstrap.)

## Verification

Applied locally and confirmed via a real-pty headless load (`errors=0`): gruvbox active, `termguicolors=1`, `:Commentary` and `:GitGutter` present, `vim-visual-multi` loaded. All 8 plugins installed cleanly into `~/.vim/plugged`.

## Note for fresh installs

The old `~/.vim/bundle/` (Vundle) is no longer referenced and can be removed (`rm -rf ~/.vim/bundle`); it's harmless if left.