### PR TITLE
chore(homebrew): add cmux cask

### DIFF
--- a/homebrew/Brewfile
+++ b/homebrew/Brewfile
@@ -15,6 +15,7 @@ brew "vim"
 
 # editors
 cask "visual-studio-code"
+cask "cmux"
 
 # apps
 cask "arc"


### PR DESCRIPTION
## Summary
- Add the [`cmux`](https://formulae.brew.sh/cask/cmux) cask to the Homebrew `Brewfile` so it gets installed via `brew bundle`.
- Placed it alongside the other editor/dev tools.

## Notes
- `.zshrc` changes are intentionally excluded (machine-specific).